### PR TITLE
Align API with outlier protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
-# py_lstm
-LSTM model for the outlier Classifier
+# py_cnn_fft
+FastAPI service implementing a CNN model with FFT features.  The API follows
+the endpoints defined in the [outlier protocol](../outlier_protocol) so it can
+be integrated with the orchestrator.


### PR DESCRIPTION
## Summary
- implement start and push endpoints for training
- accept single discharge at `/predict`
- add helper for background training
- expose model name in health response
- document compatibility with outlier protocol

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686572e5255483289db0ed66c9f0b341