### PR TITLE
Adapt CNN-FFT service to outlier protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
-# py_lstm
-LSTM model for the outlier Classifier
+# fft_cnn
+CNN-FFT model compatible with the Outlier Protocol
+
+This service exposes the endpoints defined in `outlier_protocol/protocol.yaml`:
+
+- `GET /health`
+- `POST /train`
+- `POST /train/{ordinal}`
+- `POST /predict`
+
+Set the environment variable `ORCHESTRATOR_URL` so the server can notify the
+control plane via the `/trainingCompleted` webhook once training finishes.


### PR DESCRIPTION
## Summary
- implement StartTrainingRequest/Response and DischargeAck
- add training session endpoints `/train` and `/train/{ordinal}`
- send `trainingCompleted` webhook when training ends
- adjust prediction and health endpoints to match protocol
- document new behaviour in README

## Testing
- `python -m py_compile main.py signals.py zscore_normalizer.py`

------
https://chatgpt.com/codex/tasks/task_e_686572e5255483289db0ed66c9f0b341